### PR TITLE
Serverspec v2

### DIFF
--- a/ruby.serverspec.snip
+++ b/ruby.serverspec.snip
@@ -34,6 +34,11 @@ snippet command_its_stdout_stderr
       its(:stderr) { should match /${4:pattern}/ }
     end
 
+snippet command_its_exit_status
+    describe command('${1:command}') do
+      its(:exit_status) { should eq ${2:pattern} }
+    end
+
 # cron http://serverspec.org/resource_types.html#cron 
 snippet cron
     describe cron do
@@ -137,6 +142,12 @@ snippet file_match_md5checksum
 
 snippet file_match_sha256checksum
     it { should match_sha256checksum '${1:sha256checksum}' }
+
+snippet file_its_md5checksum
+    its(:md5sum) { should eq '${1:md5sum}' }
+
+snippet file_its_sha256sum
+    its(:sha256sum) { should eq '${1:sha256sum}' }
 
 snippet file_resource
     it { should be_file }


### PR DESCRIPTION
Serverspec v2 removed some obsoleted matchers, so added new 'its' matchers instead.
- https://github.com/serverspec/serverspec/pull/464
- https://github.com/serverspec/serverspec/pull/465
### before

``` ruby
describe command('command') do
  it { should return_stdout 'foo' }
  it { should return_stderr 'bar' }
  it { should return_exit_status 0 }
end
describe file('/foo') do
  it { should match_md5checksum('fdcb69b5c0e9beb7d392fbc458bc6beb')
  it { should match_sha256sum('17feb8dc0817056a963c2861052d670b642c61f5625fae1fd59a2022be1dbb5b') }
end
```
### after

``` ruby
describe command('command') do
  its(:stdout) { should eq "foo\n" }
  its(:stderr) { should match /bar/ }
  its(:exit_status) { should eq 0 }
end
describe file('/foo') do
  its(:md5sum)    { should eq 'fdcb69b5c0e9beb7d392fbc458bc6beb' }
  its(:sha256sum) { should eq '17feb8dc0817056a963c2861052d670b642c61f5625fae1fd59a2022be1dbb5b' }
end
```
