### PR TITLE
Update service snippets

### DIFF
--- a/ruby.serverspec.snip
+++ b/ruby.serverspec.snip
@@ -420,8 +420,8 @@ snippet service_be_installed_for_windows
 snippet service_be_running
     it { should be_running }
 
-snippet service_be_running_under_supervisor
-    it { should be_running.under('supervisor') }
+snippet service_be_running_under
+    it { should be_running.under('${1:supervisor}') }
 
 snippet service_be_monitored_by
     it { should be_monitored_by('${1:monitored_by}')


### PR DESCRIPTION
## Summary
- fix wrong placeholder  6d701a0
- `be_running.under` supports placeholder  8b2e6e5
